### PR TITLE
Resolvido problema de sessão expirada

### DIFF
--- a/src/providers/user.provider.tsx
+++ b/src/providers/user.provider.tsx
@@ -58,13 +58,13 @@ const UserProvider: React.FC<UserProviderProps> = ({ children }: UserProviderPro
               'Não autorizado',
               'Sua sessão expirou ou seu token de acesso não é válido, faça login novamente para continuar.'
             )
+
+            forceFinishSession()
           } else if (statusCode === 403) {
             handleErrorToast(
               'Não autorizado',
               'Sua conta não está registrada ou foi desativada, entre em contato com o administrador do sistema.'
             )
-
-            forceFinishSession()
           }
         })
     }


### PR DESCRIPTION
Quando seu token expirava e o backend retornava 401 para requisições, você ainda conseguia transitar pelas telas do frontend